### PR TITLE
Ashultz0/sign token

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
         # issue is really that Django is missing to avoid masking other
         # exceptions on Python 2.
         try:
-            import django  # pylint: disable=unused-import, wrong-import-position
+            import django  # pylint: disable=unused-import
         except ImportError as import_error:
             raise ImportError(
                 "Couldn't import Django. Are you sure it's installed and "

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,4 +2,4 @@
 -c constraints.txt
 
 Django             # Web application framework
-
+pyjwkest           # JWT token signing and validation

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,11 +6,29 @@
 #
 asgiref==3.5.2
     # via django
+certifi==2022.6.15
+    # via requests
+charset-normalizer==2.1.1
+    # via requests
 django==3.2.15
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
+future==0.18.2
+    # via pyjwkest
+idna==3.3
+    # via requests
+pycryptodomex==3.15.0
+    # via pyjwkest
+pyjwkest==1.4.2
+    # via -r requirements/base.in
 pytz==2022.2.1
     # via django
+requests==2.28.1
+    # via pyjwkest
+six==1.16.0
+    # via pyjwkest
 sqlparse==0.4.2
     # via django
+urllib3==1.26.12
+    # via requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -24,12 +24,14 @@ build==0.8.0
 certifi==2022.6.15
     # via
     #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
     #   requests
 chardet==5.0.0
     # via diff-cover
 charset-normalizer==2.1.1
     # via
     #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
     #   requests
 click==8.1.3
     # via
@@ -79,9 +81,14 @@ filelock==3.8.0
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
+future==0.18.2
+    # via
+    #   -r requirements/quality.txt
+    #   pyjwkest
 idna==3.3
     # via
     #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
     #   requests
 iniconfig==1.1.1
     # via
@@ -151,10 +158,16 @@ py==1.11.0
     #   tox
 pycodestyle==2.9.1
     # via -r requirements/quality.txt
+pycryptodomex==3.15.0
+    # via
+    #   -r requirements/quality.txt
+    #   pyjwkest
 pydocstyle==6.1.1
     # via -r requirements/quality.txt
 pygments==2.13.0
     # via diff-cover
+pyjwkest==1.4.2
+    # via -r requirements/quality.txt
 pylint==2.14.5
     # via
     #   -r requirements/quality.txt
@@ -206,12 +219,15 @@ pyyaml==6.0
 requests==2.28.1
     # via
     #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
     #   codecov
+    #   pyjwkest
 six==1.16.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   edx-lint
+    #   pyjwkest
     #   tox
 snowballstemmer==2.2.0
     # via
@@ -260,6 +276,7 @@ typing-extensions==4.3.0
 urllib3==1.26.12
     # via
     #   -r requirements/ci.txt
+    #   -r requirements/quality.txt
     #   requests
 virtualenv==20.16.3
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -21,9 +21,13 @@ bleach==5.0.1
 build==0.8.0
     # via -r requirements/doc.in
 certifi==2022.6.15
-    # via requests
+    # via
+    #   -r requirements/test.txt
+    #   requests
 charset-normalizer==2.1.1
-    # via requests
+    # via
+    #   -r requirements/test.txt
+    #   requests
 click==8.1.3
     # via
     #   -r requirements/test.txt
@@ -48,8 +52,14 @@ docutils==0.19
     #   readme-renderer
     #   restructuredtext-lint
     #   sphinx
+future==0.18.2
+    # via
+    #   -r requirements/test.txt
+    #   pyjwkest
 idna==3.3
-    # via requests
+    # via
+    #   -r requirements/test.txt
+    #   requests
 imagesize==1.4.1
     # via sphinx
 importlib-metadata==4.12.0
@@ -94,12 +104,18 @@ py==1.11.0
     # via
     #   -r requirements/test.txt
     #   pytest
+pycryptodomex==3.15.0
+    # via
+    #   -r requirements/test.txt
+    #   pyjwkest
 pygments==2.13.0
     # via
     #   doc8
     #   readme-renderer
     #   rich
     #   sphinx
+pyjwkest==1.4.2
+    # via -r requirements/test.txt
 pyparsing==3.0.9
     # via
     #   -r requirements/test.txt
@@ -130,6 +146,8 @@ readme-renderer==37.0
     # via twine
 requests==2.28.1
     # via
+    #   -r requirements/test.txt
+    #   pyjwkest
     #   requests-toolbelt
     #   sphinx
     #   twine
@@ -142,7 +160,10 @@ rfc3986==2.0.0
 rich==12.5.1
     # via twine
 six==1.16.0
-    # via bleach
+    # via
+    #   -r requirements/test.txt
+    #   bleach
+    #   pyjwkest
 snowballstemmer==2.2.0
     # via sphinx
 sphinx==5.1.1
@@ -186,6 +207,7 @@ typing-extensions==4.3.0
     # via rich
 urllib3==1.26.12
     # via
+    #   -r requirements/test.txt
     #   requests
     #   twine
 webencodings==0.5.1

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -16,6 +16,14 @@ attrs==22.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
+certifi==2022.6.15
+    # via
+    #   -r requirements/test.txt
+    #   requests
+charset-normalizer==2.1.1
+    # via
+    #   -r requirements/test.txt
+    #   requests
 click==8.1.3
     # via
     #   -r requirements/test.txt
@@ -40,6 +48,14 @@ django==3.2.15
     #   -r requirements/test.txt
 edx-lint==5.2.4
     # via -r requirements/quality.in
+future==0.18.2
+    # via
+    #   -r requirements/test.txt
+    #   pyjwkest
+idna==3.3
+    # via
+    #   -r requirements/test.txt
+    #   requests
 iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
@@ -80,8 +96,14 @@ py==1.11.0
     #   pytest
 pycodestyle==2.9.1
     # via -r requirements/quality.in
+pycryptodomex==3.15.0
+    # via
+    #   -r requirements/test.txt
+    #   pyjwkest
 pydocstyle==6.1.1
     # via -r requirements/quality.in
+pyjwkest==1.4.2
+    # via -r requirements/test.txt
 pylint==2.14.5
     # via
     #   edx-lint
@@ -121,8 +143,15 @@ pyyaml==6.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
+requests==2.28.1
+    # via
+    #   -r requirements/test.txt
+    #   pyjwkest
 six==1.16.0
-    # via edx-lint
+    # via
+    #   -r requirements/test.txt
+    #   edx-lint
+    #   pyjwkest
 snowballstemmer==2.2.0
     # via pydocstyle
 sqlparse==0.4.2
@@ -149,6 +178,10 @@ typing-extensions==4.3.0
     # via
     #   astroid
     #   pylint
+urllib3==1.26.12
+    # via
+    #   -r requirements/test.txt
+    #   requests
 wrapt==1.14.1
     # via astroid
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -10,6 +10,14 @@ asgiref==3.5.2
     #   django
 attrs==22.1.0
     # via pytest
+certifi==2022.6.15
+    # via
+    #   -r requirements/base.txt
+    #   requests
+charset-normalizer==2.1.1
+    # via
+    #   -r requirements/base.txt
+    #   requests
 click==8.1.3
     # via code-annotations
 code-annotations==1.3.0
@@ -19,6 +27,14 @@ coverage[toml]==6.4.4
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
+future==0.18.2
+    # via
+    #   -r requirements/base.txt
+    #   pyjwkest
+idna==3.3
+    # via
+    #   -r requirements/base.txt
+    #   requests
 iniconfig==1.1.1
     # via pytest
 jinja2==3.1.2
@@ -33,6 +49,12 @@ pluggy==1.0.0
     # via pytest
 py==1.11.0
     # via pytest
+pycryptodomex==3.15.0
+    # via
+    #   -r requirements/base.txt
+    #   pyjwkest
+pyjwkest==1.4.2
+    # via -r requirements/base.txt
 pyparsing==3.0.9
     # via packaging
 pytest==7.1.2
@@ -51,6 +73,14 @@ pytz==2022.2.1
     #   django
 pyyaml==6.0
     # via code-annotations
+requests==2.28.1
+    # via
+    #   -r requirements/base.txt
+    #   pyjwkest
+six==1.16.0
+    # via
+    #   -r requirements/base.txt
+    #   pyjwkest
 sqlparse==0.4.2
     # via
     #   -r requirements/base.txt
@@ -63,3 +93,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
+urllib3==1.26.12
+    # via
+    #   -r requirements/base.txt
+    #   requests

--- a/test_settings.py
+++ b/test_settings.py
@@ -59,3 +59,34 @@ TEMPLATES = [{
         ],
     },
 }]
+
+
+TOKEN_SIGNING = {
+    'JWT_ISSUER': 'token-test-issuer',
+    'JWT_SIGNING_ALGORITHM': 'RS512',
+    'JWT_SUPPORTED_VERSION': '1.2.0',
+    'JWT_PRIVATE_SIGNING_JWK': '''{
+        "e": "AQAB",
+        "d": "HIiV7KNjcdhVbpn3KT-I9n3JPf5YbGXsCIedmPqDH1d4QhBofuAqZ9zebQuxkRUpmqtYMv0Zi6ECSUqH387GYQF_XvFUFcjQRPycISd8TH0DAKaDpGr-AYNshnKiEtQpINhcP44I1AYNPCwyoxXA1fGTtmkKChsuWea7o8kytwU5xSejvh5-jiqu2SF4GEl0BEXIAPZsgbzoPIWNxgO4_RzNnWs6nJZeszcaDD0CyezVSuH9QcI6g5QFzAC_YuykSsaaFJhZ05DocBsLczShJ9Omf6PnK9xlm26I84xrEh_7x4fVmNBg3xWTLh8qOnHqGko93A1diLRCrKHOvnpvgQ",
+        "n": "o5cn3ljSRi6FaDEKTn0PS-oL9EFyv1pI7dRgffQLD1qf5D6sprmYfWWokSsrWig8u2y0HChSygR6Jn5KXBqQn6FpM0dDJLnWQDRXHLl3Ey1iPYgDSmOIsIGrV9ZyNCQwk03wAgWbfdBTig3QSDYD-sTNOs3pc4UD_PqAvU2nz_1SS2ZiOwOn5F6gulE1L0iE3KEUEvOIagfHNVhz0oxa_VRZILkzV-zr6R_TW1m97h4H8jXl_VJyQGyhMGGypuDrQ9_vaY_RLEulLCyY0INglHWQ7pckxBtI5q55-Vio2wgewe2_qYcGsnBGaDNbySAsvYcWRrqDiFyzrJYivodqTQ",
+        "q": "3T3DEtBUka7hLGdIsDlC96Uadx_q_E4Vb1cxx_4Ss_wGp1Loz3N3ZngGyInsKlmbBgLo1Ykd6T9TRvRNEWEtFSOcm2INIBoVoXk7W5RuPa8Cgq2tjQj9ziGQ08JMejrPlj3Q1wmALJr5VTfvSYBu0WkljhKNCy1KB6fCby0C9WE",
+        "p": "vUqzWPZnDG4IXyo-k5F0bHV0BNL_pVhQoLW7eyFHnw74IOEfSbdsMspNcPSFIrtgPsn7981qv3lN_staZ6JflKfHayjB_lvltHyZxfl0dvruShZOx1N6ykEo7YrAskC_qxUyrIvqmJ64zPW3jkuOYrFs7Ykj3zFx3Zq1H5568G0",
+        "kid": "token-test-sign", "kty": "RSA"
+    }''',
+    'JWT_PUBLIC_SIGNING_JWK_SET': '''{
+        "keys": [
+            {
+                "kid":"token-test-wrong-key",
+                "e": "AQAB",
+                "kty": "RSA",
+                "n": "o5cn3ljSRi6FaDEKTn0PS-oL9EFyv1pI7dffgRQLD1qf5D6sprmYfWVokSsrWig8u2y0HChSygR6Jn5KXBqQn6FpM0dDJLnWQDRXHLl3Ey1iPYgDSmOIsIGrV9ZyNCQwk03wAgWbfdBTig3QSDYD-sTNOs3pc4UD_PqAvU2nz_1SS2ZiOwOn5F6gulE1L0iE3KEUEvOIagfHNVhz0oxa_VRZILkzV-zr6R_TW1m97h4H8jXl_VJyQGyhMGGypuDrQ9_vaY_RLEulLCyY0INglHWQ7pckxBtI5q55-Vio2wgewe2_qYcGsnBGaDNbySAsvYcWRrqDiFyzrJYivodqTQ"
+            },
+            {
+                "kid":"token-test-sign",
+                "e": "AQAB",
+                "kty": "RSA",
+                "n": "o5cn3ljSRi6FaDEKTn0PS-oL9EFyv1pI7dRgffQLD1qf5D6sprmYfWWokSsrWig8u2y0HChSygR6Jn5KXBqQn6FpM0dDJLnWQDRXHLl3Ey1iPYgDSmOIsIGrV9ZyNCQwk03wAgWbfdBTig3QSDYD-sTNOs3pc4UD_PqAvU2nz_1SS2ZiOwOn5F6gulE1L0iE3KEUEvOIagfHNVhz0oxa_VRZILkzV-zr6R_TW1m97h4H8jXl_VJyQGyhMGGypuDrQ9_vaY_RLEulLCyY0INglHWQ7pckxBtI5q55-Vio2wgewe2_qYcGsnBGaDNbySAsvYcWRrqDiFyzrJYivodqTQ"
+            }
+        ]
+    }''',
+}

--- a/token_utils/api.py
+++ b/token_utils/api.py
@@ -1,0 +1,17 @@
+"""
+Public API for token_utils.
+"""
+from token_utils.sign import create_jwt
+
+
+def sign_token_for(lms_user_id, expires_in_seconds, additional_token_claims):
+    """
+    Produce a signed JWT token indicating some temporary permission for the indicated user.
+
+    What permission that is must be encoded in additional_claims.
+    Arguments:
+        lms_user_id (int): LMS user ID this token is being generated for
+        expires_in_seconds (int): Time to token expiry, specified in seconds.
+        additional_token_claims (dict): Additional claims to include in the token.
+    """
+    return create_jwt(lms_user_id, expires_in_seconds, additional_token_claims)

--- a/token_utils/models.py
+++ b/token_utils/models.py
@@ -1,3 +1,3 @@
 """
-Database models for token_utils.
+Token utils is not expected to have any database models.
 """

--- a/token_utils/sign.py
+++ b/token_utils/sign.py
@@ -1,0 +1,51 @@
+"""
+Token creation and signing functions.
+"""
+
+import json
+from time import time
+
+from django.conf import settings
+from jwkest import jwk
+from jwkest.jws import JWS
+
+
+def create_jwt(lms_user_id, expires_in_seconds, additional_token_claims, now=None):
+    """
+    Produce an encoded JWT (string) indicating some temporary permission for the indicated user.
+
+    What permission that is must be encoded in additional_claims.
+    Arguments:
+        lms_user_id (int): LMS user ID this token is being generated for
+        expires_in_seconds (int): Time to token expiry, specified in seconds.
+        additional_token_claims (dict): Additional claims to include in the token.
+        now(int): optional now value for testing
+    """
+    now = now or int(time())
+
+    payload = {
+        'lms_user_id': lms_user_id,
+        'exp': now + expires_in_seconds,
+        'iat': now,
+        'iss': settings.TOKEN_SIGNING['JWT_ISSUER'],
+        'version': settings.TOKEN_SIGNING['JWT_SUPPORTED_VERSION'],
+    }
+    payload.update(additional_token_claims)
+    return _encode_and_sign(payload)
+
+
+def _encode_and_sign(payload):
+    """
+    Encode and sign the provided payload.
+
+    The signing key and algorithm are pulled from settings.
+    """
+    keys = jwk.KEYS()
+
+    serialized_keypair = json.loads(settings.TOKEN_SIGNING['JWT_PRIVATE_SIGNING_JWK'])
+    keys.add(serialized_keypair)
+    algorithm = settings.TOKEN_SIGNING['JWT_SIGNING_ALGORITHM']
+
+    data = json.dumps(payload)
+    jws = JWS(data, alg=algorithm)
+    return jws.sign_compact(keys=keys)

--- a/token_utils/tests/test_sign.py
+++ b/token_utils/tests/test_sign.py
@@ -1,0 +1,70 @@
+"""
+Tests for token creation and signing
+"""
+import unittest
+
+from django.conf import settings
+from jwkest import BadSignature, jwk
+from jwkest.jws import JWS
+
+from token_utils import api
+from token_utils.sign import create_jwt
+
+test_user_id = 121
+test_timeout = 60
+test_now = 1661432902
+test_claims = {"foo": "bar", "baz": "quux", "meaning": 42}
+expected_full_token = {
+    "lms_user_id": test_user_id,
+    "iat": test_now,
+    "exp": test_now + test_timeout,
+    "iss": "token-test-issuer",  # these lines from test_settings.py
+    "version": "1.2.0",  # these lines from test_settings.py
+}
+
+
+class TestSign(unittest.TestCase):
+    def test_create_jwt(self):
+        token = create_jwt(test_user_id, test_timeout, {}, test_now)
+
+        decoded = _verify_jwt(token)
+        self.assertEqual(expected_full_token, decoded)
+
+    def test_create_jwt_with_claims(self):
+        token = create_jwt(test_user_id, test_timeout, test_claims, test_now)
+
+        expected_token_with_claims = expected_full_token.copy()
+        expected_token_with_claims.update(test_claims)
+
+        decoded = _verify_jwt(token)
+        self.assertEqual(expected_token_with_claims, decoded)
+
+    def test_malformed_token(self):
+        token = create_jwt(test_user_id, test_timeout, test_claims, test_now)
+        token = token + "a"
+
+        expected_token_with_claims = expected_full_token.copy()
+        expected_token_with_claims.update(test_claims)
+
+        with self.assertRaises(BadSignature):
+            _verify_jwt(token)
+
+    def test_sign_api_hooked_up(self):
+        api_token = api.sign_token_for(test_user_id, test_timeout, test_claims)
+        decoded = _verify_jwt(api_token)
+        # we've verified full token flow above and have no now access via the API
+        # so just check that an item we know we put in came through properly
+        self.assertEqual(42, decoded['meaning'])
+        # and an item from config came through properly
+        self.assertEqual('token-test-issuer', decoded['iss'])
+
+
+def _verify_jwt(jwt_token):
+    """
+    Helper function which verifies the signature and decodes the token
+    from string back to claims form
+    """
+    keys = jwk.KEYS()
+    keys.load_jwks(settings.TOKEN_SIGNING['JWT_PUBLIC_SIGNING_JWK_SET'])
+    decoded = JWS().verify_compact(jwt_token.encode('utf-8'), keys)
+    return decoded

--- a/token_utils/urls.py
+++ b/token_utils/urls.py
@@ -5,6 +5,5 @@ from django.urls import re_path  # pylint: disable=unused-import
 from django.views.generic import TemplateView  # pylint: disable=unused-import
 
 urlpatterns = [
-    # TODO: Fill in URL patterns and views here.
-    # re_path(r'', TemplateView.as_view(template_name="token_utils/base.html")),
+    # token_utils is not expected to have any URLs
 ]


### PR DESCRIPTION
Adds a sign function, pretty simple.

The first few diffs are cleanup and requirements to get that out of the way, you are probably mostly interested in reviewing the final diff.


Contrary to ticket, this uses asymmetric signing. The reason for this is it will make key management easier since our asymmetric keys run off public key sets. That allows two things:
 * it's easy to update keys without blowing away anything in progress
 * the consumer can have public keys from multiple token sources, for example edx-exams and also edx-magic-pony, and validate them all with the appropriate key for no extra work.

https://2u-internal.atlassian.net/browse/MST-1596

