### PR TITLE
fix: remove tox-battery from requirements

### DIFF
--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -3,4 +3,3 @@
 -c constraints.txt
 
 tox                       # Virtualenv management for tests
-tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -26,8 +26,5 @@ tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.in
-    #   tox-battery
-tox-battery==0.6.2
-    # via -r requirements/ci.in
 virtualenv==20.24.6
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -251,9 +251,6 @@ tox==3.28.0
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.txt
-    #   tox-battery
-tox-battery==0.6.2
-    # via -r requirements/ci.txt
 typing-extensions==4.8.0
     # via
     #   -r requirements/quality.txt


### PR DESCRIPTION
## Description
- Remove the tox-battery package from requirements to prepare for tox4 upgrade.