### PR TITLE
chore: update ubunto version in github workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
         python-version: ['3.11']
-        toxenv: [quality, pii_check, django32, django40]
+        toxenv: [quality, pii_check, django40]
 
     steps:
     - uses: actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
       run: tox
 
     - name: Run coverage
-      if: matrix.python-version == '3.11' && matrix.toxenv == 'django32'
+      if: matrix.python-version == '3.11' && matrix.toxenv == 'django40'
       uses: py-cov-action/python-coverage-comment-action@v3
       with:
         GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
 
   push:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py311-django{32,40}
+envlist = py311-django{40}
 
 [doc8]
 ; D001 = Line too long
@@ -36,7 +36,6 @@ norecursedirs = .* docs requirements site-packages
 
 [testenv]
 deps =
-    django32: Django>=3.2,<4.0
     django40: Django>=4.0,<4.1
     -r{toxinidir}/requirements/test.txt
 commands =
@@ -86,4 +85,3 @@ deps =
     -r{toxinidir}/requirements/test.txt
 commands =
     code_annotations django_find_annotations --config_file .pii_annotations.yml --lint --report --coverage
-


### PR DESCRIPTION
Updating ubunto version in github workflows because of the following error
```
[tests (ubuntu-20.04, 3.11, django32)](https://github.com/edx/token-utils/actions/runs/14726441826/job/41330124244)
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```